### PR TITLE
Fix: aws roles in google SAML config got duplicated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.3'
-      - uses: jpkrohling/setup-operator-sdk@v1-release
+      - uses: jpkrohling/setup-operator-sdk@v1.0.2
         with:
           operator-sdk-version: v0.11.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13.3'
-      - uses: jpkrohling/setup-operator-sdk@v1-release
+      - uses: jpkrohling/setup-operator-sdk@v1.0.2
         with:
           operator-sdk-version: v0.11.0
 

--- a/internal/infrastructure/google/client.go
+++ b/internal/infrastructure/google/client.go
@@ -27,8 +27,27 @@ type User struct {
 	email string
 }
 
+func (r AwsRolesCustomSchemaDTO) Distinct() AwsRolesCustomSchemaDTO {
+	distinctRoles := make(map[string]AwsRoleCustomSchemaDTO)
+
+	for _, role := range r.Roles {
+		id := fmt.Sprintf("%s + %s", role.Type, role.Value)
+		distinctRoles[id] = role
+	}
+
+	var roles []AwsRoleCustomSchemaDTO
+	for _,role := range distinctRoles {
+		roles = append(roles, role)
+	}
+
+	return AwsRolesCustomSchemaDTO {
+		Roles:roles,
+		SessionDuration:r.SessionDuration,
+	}
+}
+
 func (r AwsRoleCustomSchemaDTO) isManaged(accountId string) bool {
-	return strings.Contains(r.Value, "/hubble-rbac/" + accountId)
+	return strings.Contains(r.Value, "/hubble-rbac/") && strings.Contains(r.Value, accountId)
 }
 
 
@@ -174,6 +193,8 @@ func (client *Client) UpdateRoles(userId string, roles []string) error {
 	if err != nil {
 		return err
 	}
+
+	currentRoles = currentRoles.Distinct()
 
 	desiredRoles := client.createDTO(roles)
 


### PR DESCRIPTION
entries are updated by first removing all managed entries and then adding them again. however the isManaged() function always returned false, which meant that the managed entries were not removed and therefore duplicated on each call to apply