### PR TITLE
Lookup external schemas in the database instead of configuration

### DIFF
--- a/internal/infrastructure/redshift/model_resolver_test.go
+++ b/internal/infrastructure/redshift/model_resolver_test.go
@@ -1,1 +1,50 @@
 package redshift
+
+import (
+	"github.com/lunarway/hubble-rbac-controller/internal/core/redshift"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Resolve(t *testing.T) {
+
+	assert := assert.New(t)
+
+	groupName := "dbtdeveloper"
+	username := "jwr"
+	externalSchemaName := "lwgoevents"
+
+	clusterIdentifiers := []string{"cluster1"}
+	users := []string{username}
+	groups := []string{groupName}
+	databases := []string{"dev"}
+	grants := []string{"public", externalSchemaName}
+	externalSchemas := []redshift.ExternalSchema{{Name: externalSchemaName, GlueDatabaseName: "lw-go-events"}}
+
+	client := NewStubRedshiftClient(users, groups, databases, grants, externalSchemas)
+	clientPool := newStubRedshiftClientFactory(client)
+	modelResolver := NewModelResolver(clientPool, &redshift.Exclusions{})
+
+	model, err := modelResolver.Resolve(clusterIdentifiers)
+
+	assert.NoError(err)
+
+	assert.Equal(1, len(model.Clusters))
+	cluster := model.Clusters[0]
+
+	assert.Equal(1, len(cluster.Databases))
+	database := cluster.Databases[0]
+
+	assert.Equal(1, len(database.Groups))
+	group := database.Groups[0]
+
+	assert.Equal(1, len(group.GrantedExternalSchemas))
+	grant := group.GrantedExternalSchemas[0]
+
+	assert.Equal(1, len(database.Users))
+	user := database.Users[0]
+
+	assert.Equal(groupName, group.Name)
+	assert.Equal(username, user.Name)
+	assert.Equal(externalSchemaName, grant.Name)
+}

--- a/internal/infrastructure/redshift/stub_client.go
+++ b/internal/infrastructure/redshift/stub_client.go
@@ -1,0 +1,65 @@
+package redshift
+
+import "github.com/lunarway/hubble-rbac-controller/internal/core/redshift"
+
+type stubRedshiftClientFactory struct {
+	client *StubRedshiftClient
+}
+
+func newStubRedshiftClientFactory(client *StubRedshiftClient) *stubRedshiftClientFactory {
+	return &stubRedshiftClientFactory{client: client}
+}
+
+func (p *stubRedshiftClientFactory) GetClusterClient(clusterIdentifier string) (RedshiftClient, error) {
+	return p.client, nil
+}
+
+func (p *stubRedshiftClientFactory) GetDatabaseClient(clusterIdentifier string, databaseName string) (RedshiftClient, error) {
+	return p.client, nil
+}
+
+type StubRedshiftClient struct {
+	users           []string
+	groups          []string
+	databases       []string
+	grants          []string
+	externalSchemas []redshift.ExternalSchema
+}
+
+func NewStubRedshiftClient(users []string, groups []string, databases []string, schemas []string, externalSchemas []redshift.ExternalSchema) *StubRedshiftClient {
+	return &StubRedshiftClient{users: users, groups: groups, databases: databases, grants: schemas, externalSchemas: externalSchemas}
+}
+
+func (c *StubRedshiftClient) Owners() ([]Row, error) {
+	owner := "owner"
+	var result []Row
+
+	for _, databaseName := range c.databases {
+		result = append(result, Row{Cells: []string{databaseName, owner}})
+	}
+
+	return result, nil
+}
+func (c *StubRedshiftClient) UsersAndGroups() ([]Row, error) {
+	var result []Row
+
+	for _, user := range c.users {
+		for _, group := range c.groups {
+			result = append(result, Row{Cells: []string{user, group}})
+		}
+	}
+
+	return result, nil
+}
+func (c *StubRedshiftClient) Groups() ([]string, error) {
+	return c.groups, nil
+}
+func (c *StubRedshiftClient) Databases() ([]string, error) {
+	return c.databases, nil
+}
+func (c *StubRedshiftClient) ExternalSchemas() ([]redshift.ExternalSchema, error) {
+	return c.externalSchemas, nil
+}
+func (c *StubRedshiftClient) Grants(groupName string) ([]string, error) {
+	return c.grants, nil
+}

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func createApplier(conf configuration.Configuration) (*service.Applier, error) {
 
 	//for some reason revoking access to the public schema in Redshift has no effect, so every reconcile would try to revoke access to all public schemas (so we skip it)
 	config := redshiftCore.ReconcilerConfig{RevokeAccessToPublicSchema: false}
-	redshiftApplier := redshift.NewApplier(clientGroup, redshiftCore.NewExclusions(excludedDatabases, excludedUsers), conf.AwsAccountId, log, config, conf.Sources)
+	redshiftApplier := redshift.NewApplier(clientGroup, redshiftCore.NewExclusions(excludedDatabases, excludedUsers), conf.AwsAccountId, log, config)
 
 	session := iam.AwsSessionFactory{}.CreateSession()
 	iamClient := iam.New(session)

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 )
 
 type ErrorCollector struct {
@@ -35,7 +34,6 @@ type Configuration struct {
 	AwsAccountId              string
 	Region                    string
 	GoogleAdminPrincipalEmail string
-	Sources                   []string
 	DryRun                    bool
 }
 
@@ -74,7 +72,6 @@ func LoadConfiguration() (Configuration, error) {
 		RedshiftMasterDatabase:    loadVariable("REDSHIFT_MASTER_DATABASE", errorCollector),
 		AwsAccountId:              loadVariable("AWS_ACCOUNT_ID", errorCollector),
 		GoogleAdminPrincipalEmail: loadVariable("GOOGLE_ADMIN_PRINCIPAL_EMAIL", errorCollector),
-		Sources:                   strings.Split(loadVariable("SOURCES", errorCollector), ","),
 		Region:                    "eu-west-1",
 		DryRun:                    loadBool("DRYRUN", errorCollector),
 	}


### PR DESCRIPTION
This will fix an issue where the Reconcilliation process was not able to determine if a schema was an "external schema" or not when it fetched the current state. Yesterday I made a dirty fix where the info was passed in as configuration, but this is a proper fix where the info is looked up in the database instead