### PR TITLE
IAM pagination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,3 +133,16 @@ bundle: manifests kustomize
 .PHONY: bundle-build
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+
+.PHONY: code/compile
+code/compile:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -o=$(COMPILE_TARGET) ./cmd/manager
+
+.PHONY: test/unit
+test/unit:
+	go test ./internal/...
+
+.PHONY: test/integration
+test/integration:
+	go test -tags integration ./internal/...

--- a/internal/infrastructure/iam/applier_test.go
+++ b/internal/infrastructure/iam/applier_test.go
@@ -32,22 +32,18 @@ func failOnError(err error) {
 func (client *Client) createUnmanagedPolicy(name string, document string) (*iam.Policy, error) {
 
 	c := iam.New(client.session)
+	var policies []*iam.Policy
 
-	response, err := c.ListPolicies(&iam.ListPoliciesInput{
+	err := c.ListPoliciesPages(&iam.ListPoliciesInput{
 		MaxItems: aws.Int64(5000),
+	}, func(page *iam.ListPoliciesOutput, lastPage bool) bool {
+		policies = append(policies, page.Policies...)
+		return true
 	})
 
 	if err != nil {
 		return nil, err
 	}
-
-	err = client.assertNotTruncated(response.IsTruncated)
-
-	if err != nil {
-		return nil, err
-	}
-
-	policies := response.Policies
 
 	policy := client.lookupPolicy(policies, name)
 	if policy != nil {

--- a/internal/infrastructure/redshift/applier_test.go
+++ b/internal/infrastructure/redshift/applier_test.go
@@ -42,7 +42,7 @@ func TestApplier_ManageResources(t *testing.T) {
 
 	logger := infrastructure.NewLogger(t)
 	excludedUsers := []string{"lunarway"}
-	excludedDatabases := []string{"template0", "postgres"}
+	excludedDatabases := []string{"template0", "template1", "postgres"}
 
 	clientGroup := NewClientGroupForTest(&localhostCredentials)
 	applier := NewApplier(clientGroup, redshift.NewExclusions(excludedDatabases, excludedUsers), "478824949770", logger, redshift.DefaultReconcilerConfig())

--- a/internal/infrastructure/redshift/client.go
+++ b/internal/infrastructure/redshift/client.go
@@ -142,6 +142,11 @@ func (c *Client) Schemas() ([]string, error) {
 }
 
 func (c *Client) ExternalSchemas() ([]redshift.ExternalSchema, error) {
+
+	if !c.externalSchemasSupported {
+		return []redshift.ExternalSchema{}, nil
+	}
+
 	rows, err := c.stringRows("select schemaname, databasename from svv_external_schemas")
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -113,7 +113,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	devMode := os.Getenv("DEVELOPMENT_MODE") != ""
+	ctrl.SetLogger(zap.New(zap.UseDevMode(devMode)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
Add pagination to all calls to IAM to avoid errors when response is paged.
Changes log format to json so it can be properly parsed in Humio